### PR TITLE
Signing of assembly references

### DIFF
--- a/StrongNaming/SetStrongNameCommand.cs
+++ b/StrongNaming/SetStrongNameCommand.cs
@@ -108,7 +108,7 @@ namespace StrongNaming
         private static byte[] GetKeyTokenFromKey(byte[] fullKey)
         {
             byte[] hash;
-            using (SHA1CryptoServiceProvider sha1 = SHA1CryptoServiceProvider.Create())
+            using (SHA1 sha1 = SHA1CryptoServiceProvider.Create())
                 hash = sha1.ComputeHash (fullKey);
 
             return hash.Reverse().Take(8).ToArray();


### PR DESCRIPTION
This commit will also add the public key token to all unsigned assembly references because signed assemblies cannot have unsigned assembly references. After that, you must also sign the referenced assemblies
