### PR TITLE
Catch BadImageFormatException

### DIFF
--- a/StrongNaming/GetAssemblyNameCommand.cs
+++ b/StrongNaming/GetAssemblyNameCommand.cs
@@ -11,9 +11,26 @@ namespace StrongNaming
     {
         protected override void ProcessAssemblyFile(string filePath)
         {
-            var name = AssemblyName.GetAssemblyName(filePath);
+            AssemblyName name;
+
+            try
+            {
+                name = AssemblyName.GetAssemblyName(filePath);
+            }
+            catch (BadImageFormatException e)
+            {
+                // TODO: localize
+                WriteError(
+                    new ErrorRecord(
+                        e,
+                        filePath + " is not a valid .NET assembly.",
+                        ErrorCategory.InvalidOperation,
+                        filePath));
+                return;
+            }
+
             var psobj = PSObject.AsPSObject(name);
-            
+
             var definition = AssemblyDefinition.ReadAssembly(filePath);
             psobj.Properties.Add(
                 new PSNoteProperty("AssemblyReferences",

--- a/StrongNaming/SetStrongNameCommand.cs
+++ b/StrongNaming/SetStrongNameCommand.cs
@@ -43,7 +43,22 @@ namespace StrongNaming
 
         protected override void ProcessAssemblyFile(string filePath)
         {
-            var assembly = AssemblyDefinition.ReadAssembly(filePath);
+            AssemblyDefinition assembly;
+            try
+            {
+                assembly = AssemblyDefinition.ReadAssembly(filePath);
+            }
+            catch (BadImageFormatException e)
+            {
+                // TODO: localize
+                WriteError(
+                    new ErrorRecord(
+                        e,
+                        filePath + " is not a valid .NET assembly.",
+                        ErrorCategory.InvalidOperation,
+                        filePath));
+                return;
+            }
 
             // Support -WhatIf
             if (ShouldProcess(assembly.FullName, _actionText))

--- a/StrongNaming/TestStrongNameCommand.cs
+++ b/StrongNaming/TestStrongNameCommand.cs
@@ -3,14 +3,25 @@ using Mono.Cecil;
 
 namespace StrongNaming
 {
+    using System;
+
     [OutputType(typeof(bool))]
     [Cmdlet(VerbsDiagnostic.Test, NounStrongName)]
     public class TestStrongNameCommand : StrongNameCommandBase
     {
         protected override void ProcessAssemblyFile(string filePath)
         {
-            var assembly = AssemblyDefinition.ReadAssembly(filePath);
-            WriteObject(assembly.Name.HasPublicKey);
+            try
+            {
+                var assembly = AssemblyDefinition.ReadAssembly(filePath);
+                WriteObject(assembly.Name.HasPublicKey);
+            }
+            catch (BadImageFormatException)
+            {
+                // TODO: localize
+                WriteVerbose("File " + filePath + " is not a valid .NET assembly.");
+                WriteObject(false);
+            }
         }
     }
 }


### PR DESCRIPTION
Handle BadImageFormatException when trying to load an assembly.

Fix for issue #9.